### PR TITLE
Refactor sidebar tree

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -65,27 +65,6 @@ html, body {
 }
 
 /* Additional styles for the modular components */
-.sidebar-tabs {
-    display: flex;
-    width: 100%;
-    padding: 10px 0;
-    border-bottom: 1px solid #ccc;
-}
-
-.tab-button {
-    flex: 1;
-    padding: 10px;
-    background: none;
-    border: none;
-    cursor: pointer;
-    font-weight: bold;
-    color: #555;
-}
-
-.tab-button.active {
-    color: #007bff;
-    border-bottom: 2px solid #007bff;
-}
 
 /* File tree container */
 .file-tree {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,10 +12,6 @@
     <div class="app-container">
         <!-- Sidebar with file tree -->
         <div class="sidebar">
-            <div class="sidebar-tabs">
-                <button id="fileBtn" class="tab-button active">Files</button>
-                <button id="promptsBtn" class="tab-button">Prompts</button>
-            </div>
             <div class="file-tree" id="fileTree">
                 <!-- File tree will be populated here dynamically -->
             </div>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -11,8 +11,6 @@ import { showError, showSuccess, toggleView } from './utils/uiUtils.js';
 import { extractLinks, validateLink, resolveLinksInText } from './utils/fileUtils.js';
 
 // DOM Elements
-const fileBtn = document.getElementById('fileBtn');
-const promptsBtn = document.getElementById('promptsBtn');
 const deleteBtn = document.getElementById('deleteBtn');
 const sidebar = document.querySelector('.sidebar');
 const sidebarResizeHandle = document.querySelector('.sidebar-resize-handle');
@@ -35,9 +33,15 @@ async function initApp() {
         // Load file tree
         await fileTreeComponent.loadFileTree();
         
-        // Set file tree select callback
+        // Set file tree callbacks
         fileTreeComponent.setOnFileSelectCallback(fileData => {
+            if (currentView !== 'file') {
+                openFileView();
+            }
             fileContentComponent.loadFileContent(fileData);
+        });
+        fileTreeComponent.setOnPromptsSelectCallback(() => {
+            openPromptsView();
         });
         
         // Setup sidebar resize functionality
@@ -47,7 +51,7 @@ async function initApp() {
         restoreSidebarWidth();
         
         // Set initial view
-        toggleView('file');
+        openFileView();
     } catch (error) {
         console.error('Error initializing app:', error);
         showError('Failed to initialize the application. Please reload the page.');
@@ -110,24 +114,20 @@ function restoreSidebarWidth() {
     }
 }
 
+function openFileView() {
+    toggleView('file');
+    currentView = 'file';
+}
+
+async function openPromptsView() {
+    toggleView('prompts');
+    currentView = 'prompts';
+    await promptsComponent.loadPrompts();
+    await substitutesComponent.loadSubstitutes();
+}
+
 // Setup event listeners
 function setupEventListeners() {
-    // File view button
-    fileBtn.addEventListener('click', () => {
-        toggleView('file');
-        currentView = 'file';
-    });
-    
-    // Prompts view button
-    promptsBtn.addEventListener('click', async () => {
-        toggleView('prompts');
-        currentView = 'prompts';
-        
-        // Load prompts and substitutes
-        await promptsComponent.loadPrompts();
-        await substitutesComponent.loadSubstitutes();
-    });
-    
     // Delete button
     deleteBtn.addEventListener('click', () => {
         deleteSelectedItem();

--- a/frontend/js/components/fileCreation.js
+++ b/frontend/js/components/fileCreation.js
@@ -144,10 +144,10 @@ class FileCreationComponent {
             if (selectedElement) {
                 const path = selectedElement.dataset.path;
                 const type = selectedElement.dataset.type;
-                
+
                 // If it's a folder, use its path as parent path
                 if (type === 'folder') {
-                    parentPath = path + '/';
+                    parentPath = path ? path + '/' : '';
                 } else {
                     // If it's a file, use its parent path
                     const pathParts = path.split('/');

--- a/frontend/js/utils/uiUtils.js
+++ b/frontend/js/utils/uiUtils.js
@@ -119,15 +119,15 @@ export function toggleView(viewName) {
         fileView.style.display = 'block';
         promptsView.classList.add('hidden');
         promptsView.style.display = 'none';
-        fileBtn.classList.add('active');
-        promptsBtn.classList.remove('active');
+        if (fileBtn) fileBtn.classList.add('active');
+        if (promptsBtn) promptsBtn.classList.remove('active');
     } else if (viewName === 'prompts') {
         fileView.classList.add('hidden');
         fileView.style.display = 'none';
         promptsView.classList.remove('hidden');
         promptsView.style.display = 'block';
-        fileBtn.classList.remove('active');
-        promptsBtn.classList.add('active');
+        if (fileBtn) fileBtn.classList.remove('active');
+        if (promptsBtn) promptsBtn.classList.add('active');
     }
 }
 


### PR DESCRIPTION
## Summary
- simplify sidebar layout by removing old tab buttons
- display `Prompts` and root `Files` entries inside file tree
- preserve folder state and prevent invalid drag moves
- update file creation logic for root selections
- add callbacks to switch main views without sidebar toggles

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684900cf3114832e9783abecfc9ab0cf